### PR TITLE
Add Sylphide formatted log coverter for MOMO4 flight log

### DIFF
--- a/MOMO_F1/sylphide/gpstime.rb
+++ b/MOMO_F1/sylphide/gpstime.rb
@@ -36,15 +36,13 @@ class GPSTime
   def GPSTime::itow(utc = Time::now)
     sec = utc - ZERO
     return nil if sec < 0
-    UTC2GPST_DELTA.each{|check_t, delta| 
-      if utc > check_t then
-        sec += delta
-        break
-      end
-    }
+    leapsec = (UTC2GPST_DELTA.find{|check_t, delta|
+      utc > check_t
+    } || [0, 0])[1]
+    sec += leapsec
     cycle, sec = sec.divmod(CYCLE_SEC)
     week, sec = sec.divmod(WEEK_SEC)
-    [cycle, week, sec]
+    [cycle, week, sec, leapsec]
   end
   
   GPST2UTC_DELTA = UTC2GPST_DELTA.collect{|utc, delta|
@@ -53,13 +51,9 @@ class GPSTime
   
   def GPSTime::utc(gpstime)
     sec = gpstime[0] * CYCLE_SEC + gpstime[1] * WEEK_SEC + gpstime[2]
-    GPST2UTC_DELTA.each{|check_t, delta| 
-      if sec > check_t then
-        sec -= delta
-        break
-      end
-    }
-    ZERO + sec
+    ZERO + sec - (GPST2UTC_DELTA.find{|check_t, delta|
+      sec > check_t
+    } || [0, 0])[1]
   end
 end
 

--- a/MOMO_F3/sylphide/sylphide_conv.rb
+++ b/MOMO_F3/sylphide/sylphide_conv.rb
@@ -67,7 +67,7 @@ pos_vel_csv = proc{|dst|
 opt[:posvel] = Pathname::new(pos_vel_csv.path).relative_path_from(opt[:data_dir]).to_s
 
 system(
-    ([File::join(File::dirname($0), '..', '..', 'MOMO_TF1', 'sylphide', 'sylphide_conv.rb')] \
+    ([File::join(File::dirname($0), '..', '..', 'MOMO_F1', 'sylphide', 'sylphide_conv.rb')] \
     + opt.collect{|k, v|
       "--#{k}='#{v}'"
     } + ARGV).join(' '))

--- a/MOMO_F4/sylphide/README.md
+++ b/MOMO_F4/sylphide/README.md
@@ -1,0 +1,23 @@
+File converter of MOMO4 CSV files to Sylphide format log
+=============
+
+How to use is just type the following in Ruby available environment
+
+```shell
+$ ruby sylphide_conv.rb > log.dat
+```
+
+* The default is to use C_band/PC1/gyro_5f_[aw][xyz].csv and C_band/PC1/gps_a.csv to generate log.dat.
+
+-------------
+
+MOMO4のCSVデータをSylphide形式に変換する
+=============
+
+使い方はRubyが使える環境で以下をタイプするだけ
+
+```shell
+$ ruby sylphide_conv.rb > log.dat
+```
+
+* 基本動作ではC_band/PC1/gyro_5f_[aw][xyz].csvとC_band/PC1/gps_a.csvからlog.datを生成しています。

--- a/MOMO_F4/sylphide/sylphide_conv.rb
+++ b/MOMO_F4/sylphide/sylphide_conv.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/ruby
+# coding: cp932
+
+opt = {
+  :data_dir => File::join(File::dirname(__FILE__), '..', 'telemetry_csv', 'C_band', 'PC1'),
+  :basetime => "2019-07-17 16:20:00 +0900", # according to http://www.istellartech.com/7hbym/wp-content/uploads/2019/07/IST-PressRelease_2019072901.pdf
+  :inertial_prefix => 'gyro_5f',
+  :posvel => 'gps_a.csv',
+  :prefix => '',
+}
+
+ARGV.reject!{|arg|
+  next false if arg !~ /--([^=]+)=?/
+  k, v = [$1.to_sym, $']
+  next false unless opt.include?(k)
+  opt[k] = v
+  true
+}
+
+system(
+    ([File::join(File::dirname($0), '..', '..', 'MOMO_F3', 'sylphide', 'sylphide_conv.rb')] \
+    + opt.collect{|k, v|
+      "--#{k}='#{v}'"
+    } + ARGV).join(' '))


### PR DESCRIPTION
This PR adds log format converter for MOMO4 flight data.

![MOMO4 attitude time history](https://user-images.githubusercontent.com/4583735/62413841-c3314080-b64e-11e9-9b65-43369a528a66.png)
The above figure is the attitude time history of MOMO4, which is an indirect artifact not included into this PR. [The definition of the angles](https://commons.wikimedia.org/wiki/File:MISB_ST_0601.8_-_Yaw,_Pitch_%26_Roll.png) is same as #3. The launch GPS time was 285618 sec (on 2062 week). According to the graph, before telemetry is down around 285670 sec, the rocket seems to be kept its initial attitude well. It is noted that the time history after outage of telemetry is not trustworthy because the long interval of data sampling results in excess of tracking capacity of Kalman filter.