### PR TITLE
Add Sylphide format log coverter for MOMO5 flight log

### DIFF
--- a/MOMO_F1/sylphide/log_mixer.rb
+++ b/MOMO_F1/sylphide/log_mixer.rb
@@ -227,7 +227,7 @@ src = {
 }
 $log_mix.call({:readers => [
   IMU_CSV::new(open(src[:imu])),
-  GPS_UBX::new(open(src[:gps])), 
+  GPS_UBX::new(open(src[:gps], 'rb')), 
 ]})
 
 end

--- a/MOMO_F1/sylphide/sylphide_conv.rb
+++ b/MOMO_F1/sylphide/sylphide_conv.rb
@@ -162,7 +162,7 @@ posvel2ubx = proc{|out|
 
 require 'tempfile'
 data_mod = Hash[*({:inertial => inertial2imu_csv, :posvel => posvel2ubx}.collect{|k, f|
-  out = f.call(Tempfile::open(File::basename(__FILE__, '.*')))
+  out = f.call(Tempfile::open(File::basename(__FILE__, '.*'), mode: File::BINARY))
   out.close
   [k, out]
 }.flatten(1))]
@@ -183,4 +183,5 @@ log_prop = {
     GPS_UBX::new(data_mod[:posvel].open), 
   ],
 }
+STDOUT.binmode
 $log_mix.call(log_prop.merge({:out => $stdout}))

--- a/MOMO_F3/sylphide/sylphide_conv.rb
+++ b/MOMO_F3/sylphide/sylphide_conv.rb
@@ -51,7 +51,7 @@ inertial_csv = proc{
   }
 }.call
 
-opt[:inertial] = Pathname::new(inertial_csv.path).relative_path_from(opt[:data_dir]).to_s
+opt[:inertial] = Pathname::new(inertial_csv.path).relative_path_from(Pathname::new(opt[:data_dir])).to_s
 
 pos_vel_csv = proc{|dst|
   Tempfile::open(File::basename(opt[:posvel], '.*'), opt[:data_dir]){|dst|
@@ -64,10 +64,11 @@ pos_vel_csv = proc{|dst|
   }
 }.call
 
-opt[:posvel] = Pathname::new(pos_vel_csv.path).relative_path_from(opt[:data_dir]).to_s
+opt[:posvel] = Pathname::new(pos_vel_csv.path).relative_path_from(Pathname::new(opt[:data_dir])).to_s
 
-system(
-    ([File::join(File::dirname($0), '..', '..', 'MOMO_F1', 'sylphide', 'sylphide_conv.rb')] \
+cmd = (
+    (['ruby', File::join(File::dirname($0), '..', '..', 'MOMO_F1', 'sylphide', 'sylphide_conv.rb')] \
     + opt.collect{|k, v|
       "--#{k}='#{v}'"
     } + ARGV).join(' '))
+raise("Runtime error! #{cmd}") unless system(cmd)

--- a/MOMO_F4/sylphide/sylphide_conv.rb
+++ b/MOMO_F4/sylphide/sylphide_conv.rb
@@ -17,8 +17,8 @@ ARGV.reject!{|arg|
   true
 }
 
-system(
-    ([File::join(File::dirname($0), '..', '..', 'MOMO_F3', 'sylphide', 'sylphide_conv.rb')] \
+cmd = (['ruby', File::join(File::dirname($0), '..', '..', 'MOMO_F3', 'sylphide', 'sylphide_conv.rb')] \
     + opt.collect{|k, v|
       "--#{k}='#{v}'"
-    } + ARGV).join(' '))
+    } + ARGV).join(' ')
+raise("Runtime error! #{cmd}") unless system(cmd)

--- a/MOMO_F5/sylphide/README.md
+++ b/MOMO_F5/sylphide/README.md
@@ -1,0 +1,23 @@
+File converter of MOMO5 CSV files to Sylphide format log
+=============
+
+How to use is just type the following in Ruby available environment
+
+```shell
+$ ruby sylphide_conv.rb > log.dat
+```
+
+* The default is to use C_band/gyro_5f_[aw][xyz].csv and C_band/gps_a.csv to generate log.dat.
+
+-------------
+
+MOMO5のCSVデータをSylphide形式に変換する
+=============
+
+使い方はRubyが使える環境で以下をタイプするだけ
+
+```shell
+$ ruby sylphide_conv.rb > log.dat
+```
+
+* 基本動作ではC_band/gyro_5f_[aw][xyz].csvとC_band/gps_a.csvからlog.datを生成しています。

--- a/MOMO_F5/sylphide/sylphide_conv.rb
+++ b/MOMO_F5/sylphide/sylphide_conv.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/ruby
+# coding: cp932
+
+opt = {
+  :data_dir => File::join(File::dirname(__FILE__), '..', 'telemetry_csv', 'C_band'),
+  :basetime => "20120-06-14 05:15:00 +0900", # according to http://www.istellartech.com/7hbym/wp-content/uploads/2020/06/d1db3cdf9f6d98cad79b276454879ce3.pdf
+  :inertial_prefix => 'gyro_5f',
+  :posvel => 'gps_a.csv',
+  :prefix => '',
+}
+
+ARGV.reject!{|arg|
+  next false if arg !~ /--([^=]+)=?/
+  k, v = [$1.to_sym, $']
+  next false unless opt.include?(k)
+  opt[k] = v
+  true
+}
+
+cmd = (['ruby', File::join(File::dirname($0), '..', '..', 'MOMO_F3', 'sylphide', 'sylphide_conv.rb')] \
+    + opt.collect{|k, v|
+      "--#{k}='#{v}'"
+    } + ARGV).join(' ')
+raise("Runtime error! #{cmd}") unless system(cmd)


### PR DESCRIPTION
This PR includes a log converter for MOMO F5 flight; an updated version of previous PR #6 .
Some bugs occurred in Windows Ruby platform are also fixed.